### PR TITLE
fix: header include miss

### DIFF
--- a/Source/DFoundryFX/Private/DFoundryFX_StatData.cpp
+++ b/Source/DFoundryFX/Private/DFoundryFX_StatData.cpp
@@ -1,4 +1,5 @@
 #include "DFoundryFX_StatData.h"
+#include "DFoundryFX_Module.h"
 #include <type_traits>
 
 DECLARE_CYCLE_STAT(TEXT("DFoundryFX_StatLoadDefault"), STAT_StatLoadDefault, STATGROUP_DFoundryFX);


### PR DESCRIPTION
add header include fix DFoundryFX_StatData.cpp complie issuse